### PR TITLE
Adiciona tela de fim de jogo no xeque-mate

### DIFF
--- a/board_helper.py
+++ b/board_helper.py
@@ -12,8 +12,6 @@ tela = pygame.display.set_mode((largura,altura))
 pygame.display.set_caption('Jogo')
 clock = pygame.time.Clock()
 
-tabuleiro: Board = Board(tela, tamanho)
-
 def selecionado(x,y):
     x = x/tamanho
     y = y/tamanho

--- a/main.py
+++ b/main.py
@@ -6,23 +6,10 @@ from classes.match import Match
 from board_helper import *
 from menu import Menu
 
-jogo: Match = Match(tabuleiro)
-
-sel_x, sel_y = 20000, 30000
-x, y = 0, 0
-peca: Piece = Piece()
-white_turn = True
-check = False
-movimentos_validos = []
-
 game_loop = True
 game_state = "menu"
 menu = Menu(tela, game_loop, game_state)
 show_possible_moves = True
-
-pecas = tabuleiro.get_pieces(white_turn)
-for p in pecas:
-    p.possible_moves(check)
 
 while game_loop:
     tela.fill('black')
@@ -30,6 +17,22 @@ while game_loop:
         game_loop, game_state = menu.draw()
     elif game_state == "options":
         show_possible_moves, game_state = menu.options(show_possible_moves)
+    elif game_state == "checkmate":
+        game_loop, game_state = menu.checkmate(winner)
+    elif game_state == "new_game":
+        tabuleiro: Board = Board(tela, tamanho)
+        jogo: Match = Match(tabuleiro)
+        sel_x, sel_y = 20000, 30000
+        x, y = 0, 0
+        peca: Piece = Piece()
+        white_turn = True
+        check = False
+        movimentos_validos = []
+        pecas = tabuleiro.get_pieces(white_turn)
+        for p in pecas:
+            p.possible_moves(check)
+        game_state = "game"
+
     elif game_state == "game":
         tabuleiro.desenhar_tabuleiro()
 
@@ -83,7 +86,9 @@ while game_loop:
                             p.possible_moves(check)
                             
                         if jogo.is_checkmate(white_turn, check):
-                            # tela de fim de jogo: xeque-mate
+                            game_state = "checkmate"
+                            menu.game_state = game_state
+                            winner = "black" if white_turn else "white"
                             pass
                         # tabuleiro.printa()
                         

--- a/menu.py
+++ b/menu.py
@@ -35,7 +35,7 @@ class Menu:
                 pygame.quit()
             if event.type == pygame.MOUSEBUTTONUP:
                 if self.botao_play_rect.collidepoint(mouse_pos):
-                    self.game_state = "game"
+                    self.game_state = "new_game"
                     self.game_loop = True
                 elif self.botao_exit_rect.collidepoint(mouse_pos):
                     self.game_loop = False
@@ -93,3 +93,33 @@ class Menu:
         pygame.draw.rect(self.tela, cor_desativado, (self.tela.get_width() // 2, self.tela.get_height() // 2, 200, 50), 2)
         pygame.display.update()
         return show_possible_moves, self.game_state
+    
+    def checkmate(self, color):
+        self.tela.blit(self.background, (0, 0))
+        fonte = pygame.font.SysFont('Arial', self.tela.get_height() // 20)
+        texto_xeque = fonte.render('XEQUE-MATE', True, (0, 0, 0))
+        texto_xeque_fundo = pygame.Surface((texto_xeque.get_width() + 20, texto_xeque.get_height() + 10))
+        texto_xeque_fundo.fill((255, 255, 255))
+        texto_xeque_fundo.blit(texto_xeque, (10, 5))
+        self.tela.blit(texto_xeque_fundo, (self.tela.get_width() // 2 - texto_xeque_fundo.get_width() // 2, self.tela.get_height() // 4 - texto_xeque_fundo.get_height() // 2))
+        texto_vencedor = fonte.render(f"O jogador {color.upper()} venceu!", True, (255, 255, 255))
+        botao_voltar = pygame.Rect(self.tela.get_width() // 2 - 100, self.tela.get_height() - 100, 200, 50)
+        texto_voltar = fonte.render('VOLTAR', True, (0, 0, 0))
+        self.tela.blit(texto_vencedor, ((self.tela.get_width() // 2) - texto_vencedor.get_width() // 2, self.tela.get_height() // 2 + texto_vencedor.get_height() // 2))
+        pygame.draw.rect(self.tela, (0, 0, 0), botao_voltar, 2)
+        self.tela.blit(texto_voltar, (self.tela.get_width() // 2 - texto_voltar.get_width() // 2, self.tela.get_height() - 75 - texto_voltar.get_height() // 2))
+        for event in pygame.event.get():
+            mouse_pos = pygame.mouse.get_pos()
+            if (event.type == pygame.QUIT):
+                pygame.quit()
+                exit()
+            if event.type == pygame.MOUSEBUTTONUP:
+                if botao_voltar.collidepoint(mouse_pos):
+                    self.game_state = "menu"
+        texto_vencedor_fundo = pygame.Surface((texto_vencedor.get_width() + 20, texto_vencedor.get_height() + 10))
+        texto_vencedor_fundo.fill((0, 0, 0))
+        texto_vencedor_fundo.blit(texto_vencedor, (10, 5))
+        self.tela.blit(texto_vencedor_fundo, (self.tela.get_width() // 2 - texto_vencedor_fundo.get_width() // 2, self.tela.get_height() // 2 + texto_vencedor_fundo.get_height() // 2))
+
+        pygame.display.update()
+        return self.game_loop, self.game_state


### PR DESCRIPTION
Closes #17 

Ao detectar xeque-mate, muda pra tela de fim de jogo mostrando o vencedor e dá opção de voltar ao menu.
Mudei a lógica de inicialização do tabuleiro pra main pra recomeçar toda vez que clicar em play, que entrará no game_state new_game, e logo após a inicialização, entre no game_state game, mostrando a partida.

Penso em dar mais opções como mostrar o tabuleiro de fim de jogo ao clicar em um botão nessa tela, mas vou manter como ideia de melhoria.